### PR TITLE
修改了主动发送消息处示例代码的错误

### DIFF
--- a/docs/开发/插件开发.md
+++ b/docs/开发/插件开发.md
@@ -403,7 +403,7 @@ class HelloWorldPlugin:
                 break
         if platform:
             inst = message.platform.platform_instance
-            await inst.send_msg({"user_id": 123456}, "Hello, World!")
+            await inst.send_msg({"user_id": 123456}, CommandResult().message("Hello, World!"))
 ```
 
 


### PR DESCRIPTION
将send_msg()方法第二个参数从‘hello world’字符串改为commandresult对象