### PR TITLE
fix: “接收所有消息事件”示例函数命名不恰当

### DIFF
--- a/dev/plugin.md
+++ b/dev/plugin.md
@@ -320,7 +320,7 @@ async def on_private_message(self, event: AstrMessageEvent):
 
 ```python
 @event_message_type(EventMessageType.ALL)
-async def on_private_message(self, event: AstrMessageEvent):
+async def on_all_message(self, event: AstrMessageEvent):
     yield event.plain_result("收到了一条消息。")
 ```
 


### PR DESCRIPTION
# 文档此处函数命名不恰当，修改为on_all_message更合适。
![image](https://github.com/user-attachments/assets/3757f937-1b71-43f4-a82e-a0d85cae1ffe)
