### PR TITLE
fix: 补全所有缺少的filter以免致人困惑

### DIFF
--- a/dev/star/plugin.md
+++ b/dev/star/plugin.md
@@ -376,7 +376,7 @@ async def on_all_message(self, event: AstrMessageEvent):
 #### 只接收某个消息平台的事件
 
 ```python
-@platform_adapter_type(PlatformAdapterType.AIOCQHTTP | PlatformAdapterType.QQOFFICIAL)
+@filter.platform_adapter_type(filter.PlatformAdapterType.AIOCQHTTP | filter.PlatformAdapterType.QQOFFICIAL)
 async def on_aiocqhttp(self, event: AstrMessageEvent):
     '''只接收 AIOCQHTTP 和 QQOFFICIAL 的消息'''
     yield event.plain_result("收到了一条信息")
@@ -401,7 +401,7 @@ async def test(self, event: AstrMessageEvent):
 
 ```python
 @filter.command("helloworld")
-@event_message_type(EventMessageType.PRIVATE_MESSAGE)
+@filter.event_message_type(filter.EventMessageType.PRIVATE_MESSAGE)
 async def helloworld(self, event: AstrMessageEvent):
     yield event.plain_result("你好！")
 ```
@@ -1018,7 +1018,7 @@ async def test(self, event: AstrMessageEvent):
 请务必按照以下格式编写一个工具（包括**函数注释**，AstrBot 会尝试解析该函数注释）
 
 ```py{3,4,5,6,7}
-@llm_tool(name="get_weather") # 如果 name 不填，将使用函数名
+@filter.llm_tool(name="get_weather") # 如果 name 不填，将使用函数名
 async def get_weather(self, event: AstrMessageEvent, location: str) -> MessageEventResult:
     '''获取天气信息。
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在插件文档示例中，为所有过滤器装饰器添加 `filter.` 前缀，以确保一致性并避免混淆。

文档：
- 在示例中为 `platform_adapter_type` 装饰器添加 `filter.` 前缀
- 在示例中为 `event_message_type` 装饰器添加 `filter.` 前缀
- 在示例中为 `llm_tool` 装饰器添加 `filter.` 前缀

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prefix all filter decorators in plugin documentation examples with the proper `filter.` namespace to ensure consistency and avoid confusion.

Documentation:
- Prefix `platform_adapter_type` decorator with `filter.` in examples
- Prefix `event_message_type` decorator with `filter.` in examples
- Prefix `llm_tool` decorator with `filter.` in examples

</details>