### PR TITLE
fix: 修复了会话控制的文档中错误的`from import`中的`from`,还有删除了示例代码中未定义的`bot_reply`

### DIFF
--- a/dev/star/plugin.md
+++ b/dev/star/plugin.md
@@ -527,7 +527,7 @@ AstrBot 提供了开箱即用的会话控制功能：
 导入：
 
 ```py
-from import astrbot.api.message_components as Comp
+import astrbot.api.message_components as Comp
 from astrbot.core.utils.session_waiter import (
     session_waiter,
     SessionController,
@@ -552,8 +552,8 @@ async def handle_empty_mention(self, event: AstrMessageEvent):
 
             # ...
             message_result = event.make_result()
-            message_result.chain = [Comp.Plain("先见之明")] # from import astrbot.api.message_components as Comp
-            await event.send(bot_reply) # 发送回复，不能使用 yield
+            message_result.chain = [Comp.Plain("先见之明")] # import astrbot.api.message_components as Comp
+            await event.send(message_result) # 发送回复，不能使用 yield
 
             controller.keep(timeout=60, reset_timeout=True) # 重置超时时间为 60s，如果不重置，则会继续之前的超时时间计时。
 
@@ -589,7 +589,7 @@ async def handle_empty_mention(self, event: AstrMessageEvent):
 默认情况下，AstrBot 会话控制器会将基于 `sender_id` （发送人的 ID）作为识别不同会话的标识，如果想将一整个群作为一个会话，则需要自定义会话 ID 算子。
 
 ```py
-from import astrbot.api.message_components as Comp
+import astrbot.api.message_components as Comp
 from astrbot.core.utils.session_waiter import (
     session_waiter,
     SessionFilter,


### PR DESCRIPTION
如题,修改过代码内容已经测试过可以直接运行的了

好的，这是翻译成中文的 pull request 总结：

## Sourcery 提供的总结

修复会话控制文档，更正导入语句，并在示例中将未定义的 `bot_reply` 替换为 `message_result`。

文档：
- 将会话控制文档中的 `from import astrbot.api.message_components` 更正为 `import astrbot.api.message_components`。
- 在发送回复的示例代码中，将未定义的 `bot_reply` 替换为 `message_result`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix session control documentation by correcting import statements and replacing undefined `bot_reply` with `message_result` in examples.

Documentation:
- Correct `from import astrbot.api.message_components` to `import astrbot.api.message_components` in session control docs.
- Replace undefined `bot_reply` with `message_result` in example code for sending replies.

</details>