### PR TITLE
update : 给会话控制器的示例代码添加了return的用法

### DIFF
--- a/dev/star/plugin.md
+++ b/dev/star/plugin.md
@@ -550,14 +550,15 @@ async def handle_empty_mention(self, event: AstrMessageEvent):
         async def empty_mention_waiter(controller: SessionController, event: AstrMessageEvent):
             idiom = event.message_str # 用户发来的成语，假设是 "一马当先"
 
-            if len(idiom) != 4:   # 假设用户输入的不是4字成语
-                await event.send(message_result.plain_result("成语必须是四个字的呢~"))  # 发送回复，不能使用 yield
-                return
-                # 退出当前方法，不执行后续逻辑，但此会话并未中断，后续的用户输入仍然会进入当前会话
-
             if idiom == "退出":   # 假设用户想主动退出成语接龙，输入了 "退出"
+                await event.send(event.plain_result("已退出成语接龙~"))
                 controller.stop()    # 停止会话控制器，会立即结束。
                 return
+
+            if len(idiom) != 4:   # 假设用户输入的不是4字成语
+                await event.send(event.plain_result("成语必须是四个字的呢~"))  # 发送回复，不能使用 yield
+                return
+                # 退出当前方法，不执行后续逻辑，但此会话并未中断，后续的用户输入仍然会进入当前会话
 
             # ...
             message_result = event.make_result()

--- a/dev/star/plugin.md
+++ b/dev/star/plugin.md
@@ -550,6 +550,15 @@ async def handle_empty_mention(self, event: AstrMessageEvent):
         async def empty_mention_waiter(controller: SessionController, event: AstrMessageEvent):
             idiom = event.message_str # 用户发来的成语，假设是 "一马当先"
 
+            if len(idiom) != 4:   # 假设用户输入的不是4字成语
+                await event.send(message_result.plain_result("成语必须是四个字的呢~"))  # 发送回复，不能使用 yield
+                return
+                # 退出当前方法，不执行后续逻辑，但此会话并未中断，后续的用户输入仍然会进入当前会话
+
+            if idiom == "退出":   # 假设用户想主动退出成语接龙，输入了 "退出"
+                controller.stop()    # 停止会话控制器，会立即结束。
+                return
+
             # ...
             message_result = event.make_result()
             message_result.chain = [Comp.Plain("先见之明")] # import astrbot.api.message_components as Comp


### PR DESCRIPTION
如题

## Sourcery 总结

更新插件文档中的会话控制器示例，以演示使用 return 进行提前退出和会话终止

文档：
- 演示在发送无效输入的错误消息后从会话处理程序返回
- 展示当用户输入显式退出命令时如何停止会话控制器并返回

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the session controller example in plugin documentation to demonstrate using return for early exit and session termination

Documentation:
- Illustrate returning from the session handler after sending an error message for invalid input
- Show how to stop the session controller and return when the user inputs an explicit exit command

</details>