### PR TITLE
add telegram privacy mode config

### DIFF
--- a/deploy/platform/telegram.md
+++ b/deploy/platform/telegram.md
@@ -7,6 +7,8 @@
 
 创建成功后，`BotFather` 会给你一个 `token`，请妥善保存。
 
+如果需要在群聊中使用，需要关闭Bot的 [Privacy mode](https://core.telegram.org/bots/features#privacy-mode)，对 `BotFather` 发送  `/setprivacy` 命令，然后选择bot， 再选择 `Disable`。
+
 ## 2. 配置 AstrBot
 
 1. 进入 AstrBot 的管理面板


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

文档：
- 在 telegram 部署指南中添加了禁用 Telegram 机器人隐私模式的说明，以便在群聊中使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add instructions to disable Telegram bot privacy mode for group chat usage in the telegram deployment guide

</details>