### PR TITLE
更新 docker.md

### DIFF
--- a/deploy/astrbot/docker.md
+++ b/deploy/astrbot/docker.md
@@ -13,6 +13,7 @@
 
 ```bash
 mkdir astrbot
+cd astrbot
 wget https://raw.githubusercontent.com/NapNeko/NapCat-Docker/main/compose/astrbot.yml
 sudo docker compose -f astrbot.yml up -d
 ```
@@ -42,6 +43,7 @@ sudo docker compose up -d
 
 ```bash
 mkdir astrbot
+cd astrbot
 sudo docker run -itd -p 6180-6200:6180-6200 -p 11451:11451 -v $PWD/data:/AstrBot/data -v /etc/localtime:/etc/localtime:ro -v /etc/timezone:/etc/timezone:ro --name astrbot soulter/astrbot:latest
 ```
 


### PR DESCRIPTION
新增创建目录后进入目录的命令

> 部署过程中发现如果不进行cd，会把目录映射到和Astrbot同级目录里

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 提供的摘要

文档：
- 在 Docker Compose 和 Docker run 指令中，在 `mkdir astrbot` 后添加 `cd astrbot`，以确保正确设置工作目录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add `cd astrbot` after `mkdir astrbot` in both Docker Compose and Docker run instructions to ensure the working directory is set correctly.

</details>