### PR TITLE
docs: modify the link

### DIFF
--- a/.vitepress/config/theme.ts
+++ b/.vitepress/config/theme.ts
@@ -28,7 +28,7 @@ export const themeConfig: DefaultTheme.Config = {
     },
 
     editLink: {
-        pattern: 'https://github.com/YumeYuka/AstrBot-docs/edit/v2/:path',
+        pattern: 'https://github.com/AstrBotdevs/AstrBot-docs/edit/v2/:path',
         text: '不妥之处，敬请雅正'
     },
 


### PR DESCRIPTION
## Sourcery 摘要

文档:
- 更新 VitePress editLink 模式以指向正确的 AstrBotdevs GitHub 仓库

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update VitePress editLink pattern to point to the correct AstrBotdevs GitHub repository

</details>