### PR TITLE
Add termux.md

### DIFF
--- a/.vitepress/config/sidebar.ts
+++ b/.vitepress/config/sidebar.ts
@@ -100,8 +100,8 @@ function deploy(): DefaultTheme.SidebarItem[] {
                 { text: "😁 宝塔面板部署", link: "/btpanel" },
                 { text: "🥇 1Panel 部署", link: "/1panel" },
                 { text: "😊 CasaOS 部署", link: "/casaos" },
-                { text: "😌 社区提供的部署脚本", link: "/linux-one" },
-                { text: "🤗 安卓Termux 部署", link: "/termux" },
+                // { text: "😌 社区提供的部署脚本", link: "/linux-one" },
+                { text: "🤗 安卓 Termux 部署", link: "/termux" },
             ],
         },
         {

--- a/.vitepress/config/sidebar.ts
+++ b/.vitepress/config/sidebar.ts
@@ -101,6 +101,7 @@ function deploy(): DefaultTheme.SidebarItem[] {
                 { text: "🥇 1Panel 部署", link: "/1panel" },
                 { text: "😊 CasaOS 部署", link: "/casaos" },
                 { text: "😌 社区提供的部署脚本", link: "/linux-one" },
+                { text: "🤗 安卓Termux 部署", link: "/termux" }
             ],
         },
         {

--- a/.vitepress/config/sidebar.ts
+++ b/.vitepress/config/sidebar.ts
@@ -101,7 +101,7 @@ function deploy(): DefaultTheme.SidebarItem[] {
                 { text: "🥇 1Panel 部署", link: "/1panel" },
                 { text: "😊 CasaOS 部署", link: "/casaos" },
                 { text: "😌 社区提供的部署脚本", link: "/linux-one" },
-                { text: "🤗 安卓Termux 部署", link: "/termux" }
+                { text: "🤗 安卓Termux 部署", link: "/termux" },
             ],
         },
         {

--- a/deploy/astrbot/termux.md
+++ b/deploy/astrbot/termux.md
@@ -1,0 +1,131 @@
+# 使用 Termux 部署 AstrBot
+
+> [!WARNING]
+> 本教程所使用的方法仅可在安卓机上使用，苹果设备并没有真正意义的`Termux`
+
+
+>[!TIP]
+>本教程中若未说明，`Do you want to continue?[Y/n]`(或类似)一律填`Y`或`y`
+# 准备步骤
+
+## 安装 `Termux`
+
+在[Termux 官网](https://termux.dev/cn) 可选择在[GitHub](https://github.com/termux/termux-app/releases)或[F-Droid](https://f-droid.org/en/packages/com.termux/)下载Termux
+
+## 换源(可选)
+
+>[!TIP]
+>建议更换源以获得更好的安装体验
+>但此换源并不会使`git clone`变得更快
+
+```bash
+termux-change-repo
+```
+选择第一个`Mirror grouRotate between several mirrors`
+
+随后选择第三个`Mirrors in ChinAll in Chinese Mainland`等待跑完即可
+
+# 正式部署
+
+## 安装 `proot-distro` 及 其他必须组件
+
+首先安装`uv`、`git`和`proot-distro`
+
+```bash
+pkg install uv git proot-distro
+```
+
+### 使用 `proot-distro` 安装 `ubuntu环境`
+
+>[!TIP]
+>中国大陆概率访问`GitHub`，故建议使用加速器或代理
+
+```bash
+proot-distro install ubuntu
+```
+
+### 登录 `Ubuntu环境`
+
+下载及配置完成会有提示`Log in with: proot-distro login ubuntu`,输入相同的即可登入
+
+即：
+```bash
+proot-distro login ubuntu
+```
+
+此时便进入了`Ubuntu环境`，我们需使用`apt`命令安装软件包了
+
+## 添加第三方PPA
+
+>[!TIP]
+>`Python 3.10`并不在官方的软件源中，而`uv`所要求的Python版本为3.10 ，所以进行此步为必须
+
+ ### 使用`apt`安装`software-properties-common` (添加PPA前置)
+
+```bash
+apt update
+apt install software-properties-common
+```
+
+### 添加`deadsnakes`PPA(Python官方维护)
+
+```bash
+add-apt-repository ppa:deadsnakes/ppa
+apt update
+```
+添加时你可能会看到:`Press [ENTER] to continue or Ctrl-c to cancel.` ，此时点击回车(换行)即可
+
+## 安装 `Python`
+
+在进行完以上步骤后，即可安装`Python 3.10`
+
+```bash
+apt install python3.10
+```
+
+## 克隆 `AstrBot` 仓库
+
+```bash
+git clone https://github.com/AstrBotDevs/AstrBot.git && cd AstrBot
+```
+
+## 运行 `AstrBot`
+
+```bash
+uv run main.py
+```
+
+如果一切正常，那么你可以看到`uv`在安装所需的包后出现类似的输出：
+
+```bash
+[Core] [DBUG] [platform.register:45]:  平台适配器 webchat 已注册
+```
+
+如果有，那么恭喜你，你已经部署好了`AstrBot`并且运行了
+
+接下来你可以尝试访问[localhost:6185](http://localhost:6185)验证可用性
+
+>[!TIP]
+>`Termux`与主机共享一个网络，即：`Termux`的IP地址就是主机的IP地址，你也可使用`ifconfig`查看主机IP地址
+>
+> 默认用户名和密码是 `astrbot` 和 `astrbot`。
+
+# 后记
+
+如需退出`proot-distro`，可以使用
+
+```bash
+exit
+```
+
+每次重新进入`Termux`时需重新打开 `proot` 环境并启动 `AstrBot`
+
+可以使用命令如下：
+
+```bash
+proot-distro login ubuntu
+cd AstrBot
+uv run main.py
+```
+
+接下来，你需要部署任何一个消息平台，才能够实现在消息平台上使用 AstrBot。

--- a/deploy/astrbot/termux.md
+++ b/deploy/astrbot/termux.md
@@ -63,15 +63,13 @@ proot-distro login ubuntu
  ### 使用`apt`安装`software-properties-common` (添加PPA前置)
 
 ```bash
-apt update
-apt install software-properties-common
+apt update && apt install software-properties-common
 ```
 
 ### 添加`deadsnakes`PPA(Python官方维护)
 
 ```bash
-add-apt-repository ppa:deadsnakes/ppa
-apt update
+add-apt-repository ppa:deadsnakes/ppa && apt update
 ```
 添加时你可能会看到:`Press [ENTER] to continue or Ctrl-c to cancel.` ，此时按下回车(换行)即可
 

--- a/deploy/astrbot/termux.md
+++ b/deploy/astrbot/termux.md
@@ -11,7 +11,7 @@
 
 在[Termux 官网](https://termux.dev/cn) 可选择在[GitHub](https://github.com/termux/termux-app/releases)或[F-Droid](https://f-droid.org/en/packages/com.termux/)下载Termux
 
-## 换源(可选)
+## 换源 (可选)
 
 >[!TIP]
 >建议更换源以获得更好的安装体验
@@ -61,6 +61,8 @@ proot-distro login ubuntu
 
  ### 使用`apt`安装`software-properties-common` (添加PPA前置)
 
+<!--这里不直接放termux基础环境里运行是因为他会报错，而且proot-distro也不大，性能损耗也很小-->
+
 ```bash
 apt update && apt install software-properties-common
 ```
@@ -92,11 +94,9 @@ git clone https://github.com/AstrBotDevs/AstrBot.git && cd AstrBot
 uv run main.py
 ```
 
-如果一切正常，那么你可以看到`uv`在安装所需的包后出现类似的输出：
+## 🎉 大功告成！
 
-```bash
-[Core] [DBUG] [platform.register:45]:  平台适配器 webchat 已注册
-```
+如果没有报错，那么你可以看到`uv`在安装所需的包后出现类似 `WebUI 已启动，可访问` 并附带了几条链接。
 
 如果有，那么恭喜你，你已经部署好了`AstrBot`并且运行了
 
@@ -109,11 +109,15 @@ uv run main.py
 
 # 后记
 
+## 退出
+
 如需退出`proot-distro`，可以使用
 
 ```bash
 exit
 ```
+
+## 重新启动
 
 每次重新进入`Termux`时需重新打开 `proot` 环境并启动 `AstrBot`
 
@@ -121,9 +125,51 @@ exit
 
 ```bash
 proot-distro login ubuntu
-cd AstrBot
-uv run main.py
+cd AstrBot && uv run main.py
 ```
+
+## 挂后台
+
+### 开启
+
+如需在一个session里面同时运行多个进程(eg. `AstrBot` 和 `Napcat`)，可以使用
+
+```bash
+uv run main.py &
+......
+```
+
+### 关闭
+
+上文运行后会有类似`[1] 1145`的输出，如需关闭进程，则可使用
+
+```bash
+kill -9 1145
+```
+
+或
+
+```bash
+pkill -9  -f "uv run main.py"
+```
+
+<!--↑这东西不咋靠谱捏-->
+
+>[!TIP]
+>也可以使用`screen`命令，较`&`更易操控
+>```bash
+>apt install screen         #安装screen
+>screen -S <name>           #创建新的会话
+>screen -r <name>           #重新连接会话
+>screen -ls                 #列举会话
+>screen -X -S <name>        #关闭会话
+>Ctrl + a + d               #退出当前窗口
+>```
+
+>[!WARNING]
+> 在退出时，请注意保存自己的任务，以防数据丢失
+
+## 后台存活
 
 如需让服务端在后台存活，可以在`设置`->`应用和服务`->`应用启动管理`->`Termux`改为`手动管理`并`允许后台活动`(或类似选项)
 

--- a/deploy/astrbot/termux.md
+++ b/deploy/astrbot/termux.md
@@ -162,7 +162,7 @@ pkill -9  -f "uv run main.py"
 >screen -S <name>           #创建新的会话
 >screen -r <name>           #重新连接会话
 >screen -ls                 #列举会话
->screen -X -S <name>        #关闭会话
+>screen -X -S <name> quit   #关闭会话
 >Ctrl + a + d               #退出当前窗口
 >```
 

--- a/deploy/astrbot/termux.md
+++ b/deploy/astrbot/termux.md
@@ -21,9 +21,9 @@
 ```bash
 termux-change-repo
 ```
-选择第一个`Mirror grouRotate between several mirrors`
+选择第一个`Mirror group Rotate between several mirrors`
 
-随后选择第三个`Mirrors in ChinAll in Chinese Mainland`等待跑完即可
+随后选择第三个`Mirrors in Chinese Mainland    All in Chinese Mainland`等待跑完即可
 
 # 正式部署
 

--- a/deploy/astrbot/termux.md
+++ b/deploy/astrbot/termux.md
@@ -73,7 +73,7 @@ apt install software-properties-common
 add-apt-repository ppa:deadsnakes/ppa
 apt update
 ```
-添加时你可能会看到:`Press [ENTER] to continue or Ctrl-c to cancel.` ，此时点击回车(换行)即可
+添加时你可能会看到:`Press [ENTER] to continue or Ctrl-c to cancel.` ，此时按下回车(换行)即可
 
 ## 安装 `Python`
 

--- a/deploy/astrbot/termux.md
+++ b/deploy/astrbot/termux.md
@@ -3,7 +3,6 @@
 > [!WARNING]
 > 本教程所使用的方法仅可在安卓机上使用，苹果设备并没有真正意义的`Termux`
 
-
 >[!TIP]
 >本教程中若未说明，`Do you want to continue?[Y/n]`(或类似)一律填`Y`或`y`
 # 准备步骤
@@ -125,5 +124,7 @@ proot-distro login ubuntu
 cd AstrBot
 uv run main.py
 ```
+
+如需让服务端在后台存活，可以在`设置`->`应用和服务`->`应用启动管理`->`Termux`改为`手动管理`并`允许后台活动`(或类似选项)
 
 接下来，你需要部署任何一个消息平台，才能够实现在消息平台上使用 AstrBot。


### PR DESCRIPTION
加了个termux部署的方法（虽然说好像没什么用，万一有人折腾呢，对吧

纯手搓，真的很累:P

## Sourcery 总结

文档:
- 引入 termux.md，其中包含安装 Termux、配置仓库、通过 proot-distro 设置 Ubuntu 环境、安装 Python 3.10、克隆 AstrBot 仓库以及运行机器人的分步说明

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Introduce termux.md with step-by-step instructions for installing Termux, configuring repositories, setting up an Ubuntu environment via proot-distro, installing Python 3.10, cloning the AstrBot repository, and running the bot

</details>