### PR TITLE
修正 lark.md 中关于 app_secret 的描述

### DIFF
--- a/deploy/platform/lark.md
+++ b/deploy/platform/lark.md
@@ -30,7 +30,7 @@
 - ID(id)：随意填写，用于区分不同的消息平台实例。
 - 启用(enable): 勾选。
 - app_id: 获取的 app_id
-- app_secret: QQ 官方机器人中获取的 app_secret
+- app_secret: 获取的 app_secret
 - 飞书机器人的名字
 
 如果您正在用国际版飞书，请将 `domain` 设置为 `https://open.larksuite.com`。


### PR DESCRIPTION
## Sourcery 总结

文档:
- 移除 app_secret 描述中对 QQ 官方机器人的错误引用

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Remove incorrect reference to QQ official bot in the app_secret description

</details>