### PR TITLE
docs(faq): correct wording and update external reference

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -9,15 +9,20 @@
 ### 管理面板的密码忘记了
 
 如果你忘记了 AstrBot 的管理面板的密码, 你可以在`AstrBot/data/cmd_config.json`配置文件中找到`"dashboard"`字段进行修改,
-其中`"username"`是你的用户名, `"password"`是你的密码, 经过 md5 加密。
+其中`"username"`是你的用户名, `"password"`是你的密码, 经过 md5 哈希处理。
 
-如果想要修改账号密码, 你可以这样做:
+docs:Update faq.md | fix improper word usage
 
-1. 修改`"username"`字段, 注意保留`""`, 如果不想修改用户名, 可以不修改
-2. 进入网站:[在线 md5 生成](https://www.metools.info/code/c26.html)
-3. 在转换前文本框输入你的新密码
-4. 选择 MD5 加密(32 位), 请确认选择 32 位选项
-5. 将转换后的字符粘贴至配置文件, 注意保留`""`
+假若您要修改账号及密码, 你可以这样做:
+
+> 请注意注意保留包裹字段前后的`""`
+> 例:`"username"`是正确的，但`username`缺少`""`会无法识别
+
+1. 更正用户名:修改`"username"`即可修改用户名
+2. 更正密码:先进入网站:[在线 md5 生成](https://it-tools.tech/hash-text)
+3. 在网站文本框输入你的新密码
+4. 复制下方生成的 "MD5"
+5. 将复制的文本粘贴至配置文件`"password"` 字段保存即可
 
 ## Bot 本体相关
 


### PR DESCRIPTION
更改了[文档](https://docs.astrbot.app/faq.html#%E7%AE%A1%E7%90%86%E9%9D%A2%E6%9D%BF%E7%9A%84%E5%AF%86%E7%A0%81%E5%BF%98%E8%AE%B0%E4%BA%86)中faq的更改密码部分内容

更正用词:md5是哈希处理而不是加密，哈希处理是不可逆(不可恢复)的，修改这部分内容

更改 md5 处理网址:更用户操作友好的网站，来自于开源项目IT-Tools，输出仍然是32位md5且(ping0/itdog.cn)测速相当

## Sourcery 总结

通过纠正 MD5 术语、更新外部哈希生成器链接以及改进在配置文件中修改凭据的分步指南，澄清了 FAQ 的密码重置说明。

文档：
- 将 MD5 从“加密”改为“哈希”，以反映其不可逆的特性
- 将在线 MD5 生成器链接替换为 it-tools.tech 上的用户友好工具
- 添加注释和格式，以强调在编辑 JSON 字段时保留引号

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the FAQ’s password reset instructions by correcting MD5 terminology, updating the external hash generator link, and improving step-by-step guidance for modifying credentials in the config file

Documentation:
- Change MD5 from “encryption” to “hash” to reflect its irreversible nature
- Replace the online MD5 generator link with a user-friendly tool at it-tools.tech
- Add notes and formatting to emphasize preserving quotation marks when editing the JSON fields

</details>