### PR TITLE
docs(faq): correct wording and update external reference

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -9,15 +9,25 @@
 ### 管理面板的密码忘记了
 
 如果你忘记了 AstrBot 的管理面板的密码, 你可以在`AstrBot/data/cmd_config.json`配置文件中找到`"dashboard"`字段进行修改,
-其中`"username"`是你的用户名, `"password"`是你的密码, 经过 md5 加密。
+其中`"username"`是你的用户名, 而`"password"`是你已经过程序 md5 哈希处理的密码,
 
-如果想要修改账号密码, 你可以这样做:
+假若您要修改账号及密码, 你可以这样做:
 
-1. 修改`"username"`字段, 注意保留`""`, 如果不想修改用户名, 可以不修改
-2. 进入网站:[在线 md5 生成](https://www.metools.info/code/c26.html)
-3. 在转换前文本框输入你的新密码
-4. 选择 MD5 加密(32 位), 请确认选择 32 位选项
-5. 将转换后的字符粘贴至配置文件, 注意保留`""`
+> tips:修改时请注意保留包裹字段前后的`""`   
+例: `"username"` 是正确的 ， 但`username`缺少 `""` 会无法识别
+
+1. 更正用户名:修改`"username"`即可修改用户名
+2. 更正密码:先进入网站:[在线 md5 生成](https://it-tools.tech/hash-text)
+3. 在网站文本框输入你的新密码
+
+<img width="400" height="130" alt="image" src="https://github.com/user-attachments/assets/7798c1a0-7b47-4be6-a02f-ae964bf5e4fd" />
+
+4. 复制下方生成的 "MD5"
+
+<img width="400" height="130" alt="image" src="https://github.com/user-attachments/assets/e8bf8dc4-7c7b-426c-8ea7-ce9c16efefd8" />
+
+
+5. 将复制的文本粘贴至配置文件`"password"` 字段保存即可
 
 ## Bot 本体相关
 


### PR DESCRIPTION
更改了 [文档](https://docs.astrbot.app/faq.html#%E7%AE%A1%E7%90%86%E9%9D%A2%E6%9D%BF%E7%9A%84%E5%AF%86%E7%A0%81%E5%BF%98%E8%AE%B0%E4%BA%86) 中faq的更改密码部分内容

<img width="451" height="49" alt="image" src="https://github.com/user-attachments/assets/b8832960-a3a6-49c1-9c86-7a1d837766b8" />

更正用词:md5是哈希处理而不是加密，哈希处理是不可逆(不可恢复)的，修改这部分内容

更改 md5 处理网址:用户操作友好的网站，来自于开源项目IT-Tools，输出仍然是32位md5

## Sourcery 总结

通过纠正 MD5 相关的术语，并更新在线哈希生成工具的新步骤和截图，澄清了 FAQ 中的密码重置说明。

文档：
- 澄清 MD5 是一种单向哈希，而非加密，并指出其不可逆性
- 将旧的 MD5 生成链接替换为用户友好的 it-tools.tech URL，并更新相关步骤
- 添加关于在配置文件中保留引号的提示，并包含说明该过程的截图

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the password reset instructions in the FAQ by correcting terminology around MD5 and updating the online hash generation tool with new steps and screenshots.

Documentation:
- Clarify that MD5 is a one-way hash, not encryption, and note its irreversibility
- Replace the old MD5 generation link with a user-friendly it-tools.tech URL and update the related steps
- Add tips on preserving quotation marks in the config file and include screenshots illustrating the process

</details>