### PR TITLE
更新文档站过时链接

### DIFF
--- a/.vitepress/config/theme.ts
+++ b/.vitepress/config/theme.ts
@@ -59,7 +59,7 @@ export const themeConfig: DefaultTheme.Config = {
     },
 
     socialLinks: [
-        { icon: "github", link: "https://github.com/Soulter/AstrBot" },
+        { icon: "github", link: "https://github.com/AstrBotDevs/AstrBot" },
     ],
 
     footer: {

--- a/.vitepress/config/theme.ts
+++ b/.vitepress/config/theme.ts
@@ -29,7 +29,7 @@ export const themeConfig: DefaultTheme.Config = {
     },
 
     editLink: {
-        pattern: 'https://github.com/AstrBotdevs/AstrBot-docs/edit/v2/:path',
+        pattern: 'https://github.com/AstrBotdevs/AstrBot-docs/edit/v4/:path',
         text: '不妥之处，敬请雅正'
     },
 


### PR DESCRIPTION
将右上角的 GitHub 链接以及文档页页脚的文档仓库链接(`不妥之处，敬请雅正`)更新为正确的链接。

## Sourcery 总结

修复文档站点 VitePress 主题配置中过时的 GitHub 仓库链接

杂项任务:
- 更新编辑链接模式以引用 v4 分支
- 更正 socialLinks GitHub URL 到正确的组织

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix outdated GitHub repository links in the documentation site's VitePress theme configuration

Chores:
- Update edit link pattern to reference the v4 branch
- Correct the socialLinks GitHub URL to the proper organization

</details>