### PR TITLE
在 NapCatQQ 中添加 WebSocket 客户端

### DIFF
--- a/deploy/platform/aiocqhttp/napcat.md
+++ b/deploy/platform/aiocqhttp/napcat.md
@@ -119,6 +119,8 @@ docker logs napcat
 
 - 勾选 `启用`。
 - `URL` 填写 `ws://宿主机IP:端口/ws`。如 `ws://localhost:6199/ws`或`ws://127.0.0.1:6199/ws`。
+> 注意如果是docker部署（用的本文档的docker脚本）那么填写的应该是`ws://astrbot:6199/ws`
+
 - 消息格式：`Array`
 - 心跳间隔: `5000`
 - 重连间隔: `5000`


### PR DESCRIPTION
Fixes #46
fix(对于docker用户使用了容器内网络来连接)

## Sourcery 总结

为 NapCatQQ 添加 WebSocket 客户端功能，并更新 Docker 部署文档以正确配置容器内部网络连接

新功能：
- 在 NapCatQQ 中添加 WebSocket 客户端支持

Bug 修复：
- 使 Docker 用户能够通过容器内部网络连接

文档：
- 更新 NapCatQQ Docker 部署指南，并附注说明使用 'astrbot' 作为 WebSocket 主机名

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add WebSocket client functionality to NapCatQQ and update Docker deployment documentation to correctly configure the container-internal network connection

New Features:
- Add WebSocket client support in NapCatQQ

Bug Fixes:
- Enable Docker users to connect via container-internal network

Documentation:
- Update NapCatQQ Docker deployment guide with note to use 'astrbot' as WebSocket hostname

</details>