### PR TITLE
新增Termux部署Astrobot下出现uv相关报错的解决方案

### DIFF
--- a/deploy/astrbot/termux.md
+++ b/deploy/astrbot/termux.md
@@ -143,6 +143,27 @@ uv run main.py
 >export UV_DEFAULT_INDEX="https://pypi.tuna.tsinghua.edu.cn/simple"
 >```
 
+>[!TIP]
+>如果出现了 `[WARN] uv sync 失败，重试 2/3
+  × Failed to build astrbot @ file:///root/AstrBot
+  ├─▶ Failed to install requirements from build-system.requires
+  ├─▶ Failed to install build dependencies
+  ├─▶ Failed to install: trove_classifiers-2025.9.11.17-py3-none-any.whl
+  │   (trove-classifiers==2025.9.11.17)
+  ╰─▶ failed to hardlink file from
+      /root/.cache/uv/archive-v0/10gPuxc61Audvy1Eg6SFz/trove_classifiers/.l2s.__init__.py0001
+      to
+      /root/.cache/uv/builds-v0/.tmp2lFVJx/lib/python3.10/site-packages/trove_classifiers/.l2s.__init__.py0001:
+      Operation not permitted (os error 1)
+` 可以先运行以下命令，然后再重新启动
+
+>```bash
+>echo 'export UV_LINK_MODE=copy' >> ~/.bashrc 
+>```
+>```bash
+>source ~/.bashrc
+>```
+
 ## 🎉 大功告成！
 
 如果没有报错，那么你可以看到`uv`在安装所需的包后出现类似 `WebUI 已启动，可访问` 并附带了几条链接。


### PR DESCRIPTION
添加了关于此报错的的解决方案
报错日志
  × Failed to build `astrbot @ file:///root/AstrBot`
  ├─▶ Failed to install requirements from `build-system.requires`
  ├─▶ Failed to install build dependencies
  ├─▶ Failed to install: trove_classifiers-2025.9.11.17-py3-none-any.whl
  │   (trove-classifiers==2025.9.11.17)
  ╰─▶ failed to hardlink file from
      /root/.cache/uv/archive-v0/10gPuxc61Audvy1Eg6SFz/trove_classifiers/.l2s.__init__.py0001
      to
      /root/.cache/uv/builds-v0/.tmp2lFVJx/lib/python3.10/site-packages/trove_classifiers/.l2s.__init__.py0001:
      Operation not permitted (os error 1)

解决命令
# 永久设置环境变量
echo 'export UV_LINK_MODE=copy' >> ~/.bashrc
source ~/.bashrc


头一次提交pr，如有不对，各位大佬见谅

## Sourcery 总结

文档：
- 记录 Termux 上 uv 同步失败的变通方案，方法是在 ~/.bashrc 中添加 UV_LINK_MODE=copy

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Document workaround for uv sync failure on Termux by adding UV_LINK_MODE=copy to ~/.bashrc

</details>