### PR TITLE
Add error resolution steps for astrbot installation

### DIFF
--- a/deploy/astrbot/termux.md
+++ b/deploy/astrbot/termux.md
@@ -143,9 +143,10 @@ uv run main.py
 >export UV_DEFAULT_INDEX="https://pypi.tuna.tsinghua.edu.cn/simple"
 >```
 
->[!TIP]
+## 报错解决方案
+
 >如果出现了 `[WARN] uv sync 失败，重试 2/3
-  × Failed to build astrbot @ file:///root/AstrBot
+  × Failed to build astrbot @ file:///root/
   ├─▶ Failed to install requirements from build-system.requires
   ├─▶ Failed to install build dependencies
   ├─▶ Failed to install: trove_classifiers-2025.9.11.17-py3-none-any.whl
@@ -155,7 +156,8 @@ uv run main.py
       to
       /root/.cache/uv/builds-v0/.tmp2lFVJx/lib/python3.10/site-packages/trove_classifiers/.l2s.__init__.py0001:
       Operation not permitted (os error 1)
-` 可以先运行以下命令，然后再重新启动
+
+可以先运行以下命令，然后再重新启动
 
 >```bash
 >echo 'export UV_LINK_MODE=copy' >> ~/.bashrc 


### PR DESCRIPTION
Added troubleshooting steps for installation errors related to astrbot.

## Sourcery 总结

在 Astrbot Termux 安装指南中添加一个故障排除部分，详细说明解决 `uv sync` 过程中构建和权限错误的命令。

文档：
- 在 Astrbot 的 Termux 部署文档中添加一个新的“错误解决”部分。
- 阐明错误消息路径，并建议将 `UV_LINK_MODE` 设置为 `copy` 以修复构建系统权限问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a troubleshooting section to the Astrbot Termux installation guide detailing commands to resolve build and permission errors during uv sync.

Documentation:
- Add a new "Error Resolution" section in the Termux deployment documentation for Astrbot.
- Clarify error message path and suggest setting UV_LINK_MODE to copy to fix build-system permission issues.

</details>