### PR TITLE
在一键脚本处添加uv报错解决方案，这次听取@Sjshi763的建议，采取了md格式

### DIFF
--- a/deploy/astrbot/community-deployment.md
+++ b/deploy/astrbot/community-deployment.md
@@ -17,3 +17,30 @@ wget -qO- https://raw.githubusercontent.com/zhende1113/Antlia/refs/heads/main/Sc
 ```
 
 仓库地址：[zhende1113/Antlia](https://github.com/zhende1113/Antlia/)
+
+## Termux部署报错解决方案
+
+>如果出现了 `[WARN] uv sync 失败，重试 2/3
+  × Failed to build astrbot @ file:///root/
+  ├─▶ Failed to install requirements from build-system.requires
+  ├─▶ Failed to install build dependencies
+  ├─▶ Failed to install: trove_classifiers-2025.9.11.17-py3-none-any.whl
+  │   (trove-classifiers==2025.9.11.17)
+  ╰─▶ failed to hardlink file from
+      /root/.cache/uv/archive-v0/10gPuxc61Audvy1Eg6SFz/trove_classifiers/.l2s.__init__.py0001
+      to
+      /root/.cache/uv/builds-v0/.tmp2lFVJx/lib/python3.10/site-packages/trove_classifiers/.l2s.__init__.py0001:
+      Operation not permitted (os error 1)
+
+可以先运行以下命令，然后再重新启动
+
+>仅限Termux部署环境使用！
+>仅限Termux部署环境使用！
+>仅限Termux部署环境使用！
+
+>```bash
+>echo 'export UV_LINK_MODE=copy' >> ~/.bashrc 
+>```
+>```bash
+>source ~/.bashrc
+>```

--- a/deploy/astrbot/termux.md
+++ b/deploy/astrbot/termux.md
@@ -143,9 +143,10 @@ uv run main.py
 >export UV_DEFAULT_INDEX="https://pypi.tuna.tsinghua.edu.cn/simple"
 >```
 
->[!TIP]
+## 报错解决方案
+
 >如果出现了 `[WARN] uv sync 失败，重试 2/3
-  × Failed to build astrbot @ file:///root/AstrBot
+  × Failed to build astrbot @ file:///root/
   ├─▶ Failed to install requirements from build-system.requires
   ├─▶ Failed to install build dependencies
   ├─▶ Failed to install: trove_classifiers-2025.9.11.17-py3-none-any.whl
@@ -155,7 +156,8 @@ uv run main.py
       to
       /root/.cache/uv/builds-v0/.tmp2lFVJx/lib/python3.10/site-packages/trove_classifiers/.l2s.__init__.py0001:
       Operation not permitted (os error 1)
-` 可以先运行以下命令，然后再重新启动
+
+可以先运行以下命令，然后再重新启动
 
 >```bash
 >echo 'export UV_LINK_MODE=copy' >> ~/.bashrc 


### PR DESCRIPTION
如题
脚本部分:根上次结束Termux配置的一样，主要报错大部分出现在一个脚本中，所以再次添加，这次就好@Sjshi763的建议，采取了md格式

## Sourcery 总结

记录 Termux 部署中 UV 同步失败的变通方案

文档：
- 在 community-deployment.md 中引入一个 Markdown 格式的 Termux UV 同步失败解决方案部分
- 在 termux.md 中添加一个包含 `UV_LINK_MODE=copy` 变通方案的“报错解决方案”部分

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document UV sync failure workaround for Termux deployments

Documentation:
- Introduce a markdown-formatted Termux UV sync failure resolution section in community-deployment.md
- Add a “报错解决方案” section with the UV_LINK_MODE=copy workaround in termux.md

</details>