### PR TITLE
针对主仓库 issue#3609 的文档更新

### DIFF
--- a/dev/star/plugin.md
+++ b/dev/star/plugin.md
@@ -175,6 +175,10 @@ async def on_message(self, event: AstrMessageEvent):
     print(event.message_obj.message) # AstrBot 解析出来的消息链内容
 ```
 
+>[!TIP]
+>
+>对于`plain`类型的消息，在发送中会自动使用strip()方法去除空格及换行符，可以使用零宽空格'\u200b'解决限制
+
 ### 平台适配矩阵
 
 不是所有的平台都支持所有的消息类型。下方的表格展示了 AstrBot 支持的平台和消息类型的对应关系。

--- a/dev/star/plugin.md
+++ b/dev/star/plugin.md
@@ -175,9 +175,9 @@ async def on_message(self, event: AstrMessageEvent):
     print(event.message_obj.message) # AstrBot 解析出来的消息链内容
 ```
 
->[!TIP]
+> [!TIP]
 >
->对于`plain`类型的消息，在发送中会自动使用strip()方法去除空格及换行符，可以使用零宽空格'\u200b'解决限制
+> 对于 `plain` 类型的消息，在发送中会自动使用 `strip()` 方法去除空格及换行符，可以使用零宽空格 `\u200b` 解决限制
 
 ### 平台适配矩阵
 

--- a/dev/star/plugin.md
+++ b/dev/star/plugin.md
@@ -177,7 +177,7 @@ async def on_message(self, event: AstrMessageEvent):
 
 > [!TIP]
 >
-> 对于 `plain` 类型的消息，在发送中会自动使用 `strip()` 方法去除空格及换行符，可以使用零宽空格 `\u200b` 解决限制
+> 在aiocqhttp消息适配器中，对于 `plain` 类型的消息，在发送中会自动使用 `strip()` 方法去除空格及换行符，可以使用零宽空格 `\u200b` 解决限制。
 
 ### 平台适配矩阵
 


### PR DESCRIPTION
[主项目issue](https://github.com/AstrBotDevs/AstrBot/issues/3609)
关于插件开发构建消息链时 `Plain` 消息会被进行 `strip()` 方法进行解释，并且给出workaround。

## Sourcery 总结

文档：
- 添加一个提示，解释 `plain` 消息类型在 `aiocqhttp` 适配器中会自动使用 `strip()` 处理，并建议使用零宽空格 (`\u200b`) 来保留空格。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a TIP explaining that `plain` message types are automatically processed with `strip()` in the aiocqhttp adapter and suggest using a zero-width space (`\u200b`) to preserve spacing.

</details>