### PR TITLE
主项目issue#3609第二次docs fix

### DIFF
--- a/zh/dev/star/guides/listen-message-event.md
+++ b/zh/dev/star/guides/listen-message-event.md
@@ -64,6 +64,10 @@ class AstrBotMessage:
 - `Nodes`：合并转发消息中的多个节点
 - `Poke`：戳一戳消息段
 
+> [!TIP]
+>
+> 在aiocqhttp消息适配器中，对于 `plain` 类型的消息，在发送中会自动使用 `strip()` 方法去除空格及换行符，可以使用零宽空格 `\u200b` 解决限制。
+
 在 AstrBot 中，消息链表示为 `List[BaseMessageComponent]` 类型的列表。
 
 ## 指令


### PR DESCRIPTION
之前用的旧开发文档，没看到v4文档更新了。
[主项目issue](https://github.com/AstrBotDevs/AstrBot/issues/3609)

## Sourcery 总结

文档：
- 在中文开发者指南中添加一个关于监听消息事件的提示，指出 aiocqhttp 适配器会自动去除空白字符，并建议使用零宽空格来保留格式

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a tip in the Chinese developer guide for listening to message events noting that the aiocqhttp adapter automatically strips whitespace and suggesting the use of zero-width space to retain formatting

</details>