### PR TITLE
移动 aiocqhttp 适配器对于 `plain` 类型消息使用 `strip()` 方法的提示

### DIFF
--- a/en/dev/star/guides/send-message.md
+++ b/en/dev/star/guides/send-message.md
@@ -58,6 +58,9 @@ async def helloworld(self, event: AstrMessageEvent):
 
 The above constructs a `message chain`, which will ultimately send a message containing both images and text while preserving the order.
 
+> [!TIP]
+> In the aiocqhttp message adapter, for `plain` type messages, the `strip()` method is used during sending to remove spaces and newlines. You can solve this issue by adding a zero-width space `\u200b` before the message.
+
 Similarly,
 
 **File**

--- a/en/dev/star/guides/send-message.md
+++ b/en/dev/star/guides/send-message.md
@@ -59,7 +59,7 @@ async def helloworld(self, event: AstrMessageEvent):
 The above constructs a `message chain`, which will ultimately send a message containing both images and text while preserving the order.
 
 > [!TIP]
-> In the aiocqhttp message adapter, for `plain` type messages, the `strip()` method is used during sending to remove spaces and newlines. You can solve this issue by adding a zero-width space `\u200b` before the message.
+> In the aiocqhttp message adapter, for messages of type `plain`, the `strip()` method is used during sending to remove spaces and line breaks. You can add zero-width spaces `\u200b` before and after the message to resolve this issue.
 
 Similarly,
 

--- a/zh/dev/star/guides/listen-message-event.md
+++ b/zh/dev/star/guides/listen-message-event.md
@@ -66,7 +66,7 @@ class AstrBotMessage:
 
 > [!TIP]
 >
-> 在aiocqhttp消息适配器中，对于 `plain` 类型的消息，在发送中会自动使用 `strip()` 方法去除空格及换行符，可以使用零宽空格 `\u200b` 解决限制。
+> 在 aiocqhttp 消息适配器中，对于 `plain` 类型的消息，在发送中会自动使用 `strip()` 方法去除空格及换行符，可以使用零宽空格 `\u200b` 解决限制。
 
 在 AstrBot 中，消息链表示为 `List[BaseMessageComponent]` 类型的列表。
 

--- a/zh/dev/star/guides/listen-message-event.md
+++ b/zh/dev/star/guides/listen-message-event.md
@@ -64,10 +64,6 @@ class AstrBotMessage:
 - `Nodes`：合并转发消息中的多个节点
 - `Poke`：戳一戳消息段
 
-> [!TIP]
->
-> 在 aiocqhttp 消息适配器中，对于 `plain` 类型的消息，在发送中会自动使用 `strip()` 方法去除空格及换行符，可以使用零宽空格 `\u200b` 解决限制。
-
 在 AstrBot 中，消息链表示为 `List[BaseMessageComponent]` 类型的列表。
 
 ## 指令

--- a/zh/dev/star/guides/send-message.md
+++ b/zh/dev/star/guides/send-message.md
@@ -58,6 +58,9 @@ async def helloworld(self, event: AstrMessageEvent):
 
 上面构建了一个 `message chain`，也就是消息链，最终会发送一条包含了图片和文字的消息，并且保留顺序。
 
+> [!TIP]
+> 在 aiocqhttp 消息适配器中，对于 `plain` 类型的消息，在发送中会使用 `strip()` 方法去除空格及换行符，可以在消息前添加零宽空格 `\u200b` 解决这个问题。
+
 类似地，
 
 **文件 File**

--- a/zh/dev/star/guides/send-message.md
+++ b/zh/dev/star/guides/send-message.md
@@ -59,7 +59,7 @@ async def helloworld(self, event: AstrMessageEvent):
 上面构建了一个 `message chain`，也就是消息链，最终会发送一条包含了图片和文字的消息，并且保留顺序。
 
 > [!TIP]
-> 在 aiocqhttp 消息适配器中，对于 `plain` 类型的消息，在发送中会使用 `strip()` 方法去除空格及换行符，可以在消息前添加零宽空格 `\u200b` 解决这个问题。
+> 在 aiocqhttp 消息适配器中，对于 `plain` 类型的消息，在发送中会使用 `strip()` 方法去除空格及换行符，可以在消息前后添加零宽空格 `\u200b` 以解决这个问题。
 
 类似地，
 


### PR DESCRIPTION
将该提示移动到了`发送消息`章节。

<img width="1074" height="198" alt="image" src="https://github.com/user-attachments/assets/25e40912-5e33-4479-a398-96149ef13a9d" />

我认为在原先的地方不太恰当，因为提示都说明是*在发送中*了。\
况且开发者遇到消息发送问题应该也不会去翻`接收消息事件`吧。

此外还略微调整了表达以防止误导，增加了对应页面的英语版本提示。

## Sourcery 总结

将关于在 aiocqhttp 适配器中使用 strip() 的提示从接收消息指南移至发送消息指南，润色其措辞，并添加英文版本。

文档：
- 将 aiocqhttp 适配器 strip() 提示重新定位到发送消息指南
- 添加 strip() 提示的相应英文版本
- 调整提示的措辞以提高清晰度

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move the tip regarding use of strip() in the aiocqhttp adapter from the receive-message guide to the send-message guide, refine its wording, and add an English version.

Documentation:
- Relocate the aiocqhttp adapter strip() tip to the send-message guide
- Add the corresponding English version of the strip() tip
- Adjust the tip’s wording to improve clarity

</details>