### PR TITLE
fix: update plugin marketplace URL in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # AstrBot
 _✨ 易上手的多平台 LLM 聊天机器人及开发框架（的官方文档） ✨_
 
-[查看文档](https://astrbot.soulter.top/) ｜ [问题提交](https://github.com/AstrBotDevs/AstrBot/issues)
+[查看文档](https://docs.astrbot.app/) ｜ [问题提交](https://github.com/AstrBotDevs/AstrBot/issues)
 
 [AstrBot](https://github.com/AstrBotDevs/AstrBot) 是一个松耦合、异步、支持多消息平台部署、具有易用的插件系统和完善的大语言模型（LLM）接入功能的聊天机器人及开发框架。
 

--- a/en/dev/star/plugin-publish.md
+++ b/en/dev/star/plugin-publish.md
@@ -4,6 +4,6 @@ After completing your plugin development, you can choose to publish it to the As
 
 AstrBot uses GitHub to host plugins, so you'll need to push your plugin code to the GitHub plugin repository you created earlier.
 
-You can submit your plugin by visiting the [AstrBot Plugin Marketplace](https://plugins.astrbot.top). Once on the website, click the `+` button in the bottom-right corner, fill in the basic information, author details, repository information, and other required fields. Then click the `Submit to GITHUB` button. You will be redirected to the AstrBot repository's Issue submission page. Please verify that all information is correct, then click the `Create` button to complete the plugin publication process.
+You can submit your plugin by visiting the [AstrBot Plugin Marketplace](https://plugins.astrbot.app). Once on the website, click the `+` button in the bottom-right corner, fill in the basic information, author details, repository information, and other required fields. Then click the `Submit to GITHUB` button. You will be redirected to the AstrBot repository's Issue submission page. Please verify that all information is correct, then click the `Create` button to complete the plugin publication process.
 
 ![fill out the form](/source/images/plugin-publish/image.png)

--- a/zh/dev/star/plugin-publish.md
+++ b/zh/dev/star/plugin-publish.md
@@ -4,6 +4,6 @@
 
 AstrBot 使用 GitHub 托管插件，因此你需要先将插件代码推送到之前创建的 GitHub 插件仓库中。
 
-你可以前往 [AstrBot 插件市场](https://plugins.astrbot.top) 提交你的插件。进入该网站后，点击右下角的 `+` 按钮，填写好基本信息、作者信息、仓库信息等内容后，点击 `提交到 GTIHUB` 按钮，你将会被导航到 AstrBot 仓库的 Issue 提交页面，请确认信息无误后点击 `Create` 按钮提交，即可完成插件发布。
+你可以前往 [AstrBot 插件市场](https://plugins.astrbot.app) 提交你的插件。进入该网站后，点击右下角的 `+` 按钮，填写好基本信息、作者信息、仓库信息等内容后，点击 `提交到 GTIHUB` 按钮，你将会被导航到 AstrBot 仓库的 Issue 提交页面，请确认信息无误后点击 `Create` 按钮提交，即可完成插件发布。
 
 ![fill out the form](/source/images/plugin-publish/image.png)


### PR DESCRIPTION
看起来旧的地址已经无法访问……

## Sourcery 摘要

更新文档，将主站和插件市场的过时 .top 域名 URL 替换为新的 .app 域名。

文档：
- 将 README 中的主文档链接从 https://astrbot.soulter.top 更改为 https://docs.astrbot.app
- 在英文和中文插件发布指南中，将 AstrBot 插件市场 URL 从 https://plugins.astrbot.top 更新为 https://plugins.astrbot.app

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation to replace outdated .top domain URLs with the new .app domain for the main site and plugin marketplace.

Documentation:
- Change the main documentation link in README from https://astrbot.soulter.top to https://docs.astrbot.app
- Update the AstrBot Plugin Marketplace URL in both English and Chinese plugin-publish guides from https://plugins.astrbot.top to https://plugins.astrbot.app

</details>