### PR TITLE
提供优化proot-distro下载速度备选方案与python安装方式修正

### DIFF
--- a/zh/deploy/astrbot/termux.md
+++ b/zh/deploy/astrbot/termux.md
@@ -97,7 +97,7 @@ proot-distro login ubuntu
 
 全部复制以下语句后运行
 
-<!-- 这里优化了大陆网络环境，修复了miniconda报错问题 -->
+<!-- 这里优化了大陆网络环境，修复了 Miniconda 报错问题 -->
 ```bash
 cat > install-py310.sh << EOF
 echo -e "\e[32m 开始安装python3.10 \e[0m - ASTRBOT"

--- a/zh/deploy/astrbot/termux.md
+++ b/zh/deploy/astrbot/termux.md
@@ -63,6 +63,9 @@ pkg install uv git proot-distro
 ```
 
 ### 使用 `proot-distro` 安装 `ubuntu环境`
+```bash
+proot-distro install ubuntu
+```
 
 >[!TIP]
 >中国大陆概率访问`GitHub`，故建议使用加速器或代理
@@ -72,10 +75,6 @@ pkg install uv git proot-distro
 >export PD_OVERRIDE_TARBALL_URL=https://ghfast.top/github.com/termux/proot-distro/releases/download/v4.30.1/ubuntu-questing-aarch64-pd-v4.30.1.tar.xz
 >export PD_OVERRIDE_TARBALL_SHA256=5ab35b90cd9a9f180656261ba400a135c4c01c2da4b74522118342f985c2d328
 >```
-
-```bash
-proot-distro install ubuntu
-```
 
 ### 登录 `Ubuntu环境`
 

--- a/zh/deploy/astrbot/termux.md
+++ b/zh/deploy/astrbot/termux.md
@@ -85,7 +85,11 @@ proot-distro login ubuntu
 
 ## 安装python环境
 
-全部复制以下语句中运行，即可自动安装python3.10
+
+脚本默认使用清华源下载，如不可用则可以尝试官方源：
+> `https://mirrors.tuna.tsinghua.edu.cn/anaconda/miniconda/`替换为`https://repo.anaconda.com/miniconda/`
+
+全部复制以下语句中运行
 
 <!-- 这里优化了大陆网络环境，修复了miniconda报错问题 -->
 ```bash
@@ -94,7 +98,7 @@ echo -e "\e[32m 开始安装python3.10 \e[0m - ASTRBOT"
 apt update
 apt install wget -y
 export SHELL=/bin/bash
-export miniconda_version="Miniconda3-py310_25.9.1-3-Linux-aarch64.sh"
+export miniconda_version="Miniconda3-py310_25.9.1-3-Linux-$(uname -m).sh"
 wget https://mirrors.tuna.tsinghua.edu.cn/anaconda/miniconda/${miniconda_version}
 chmod +x $miniconda_version
 ./$miniconda_version -bcu
@@ -104,6 +108,8 @@ python --version
 EOF
 chmod +x install-py310.sh&&./install-py310.sh
 ```
+
+如果安装成功，则可以在终端中看到`Python 3.10.19`
 
 ## 克隆 `AstrBot` 仓库
 

--- a/zh/deploy/astrbot/termux.md
+++ b/zh/deploy/astrbot/termux.md
@@ -95,7 +95,7 @@ proot-distro login ubuntu
 脚本默认使用清华源下载，如不可用则可以尝试官方源：
 > `https://mirrors.tuna.tsinghua.edu.cn/anaconda/miniconda/`替换为`https://repo.anaconda.com/miniconda/`
 
-全部复制以下语句中运行
+全部复制以下语句后运行
 
 <!-- 这里优化了大陆网络环境，修复了miniconda报错问题 -->
 ```bash

--- a/zh/deploy/astrbot/termux.md
+++ b/zh/deploy/astrbot/termux.md
@@ -66,6 +66,12 @@ pkg install uv git proot-distro
 
 >[!TIP]
 >中国大陆概率访问`GitHub`，故建议使用加速器或代理
+>
+>或者也可以执行这两条指令来使用镜像
+>```bash
+>export PD_OVERRIDE_TARBALL_URL=https://ghfast.top/github.com/termux/proot-distro/releases/download/v4.30.1/ubuntu-questing-aarch64-pd-v4.30.1.tar.xz
+>export PD_OVERRIDE_TARBALL_SHA256=5ab35b90cd9a9f180656261ba400a135c4c01c2da4b74522118342f985c2d328
+>```
 
 ```bash
 proot-distro install ubuntu

--- a/zh/deploy/astrbot/termux.md
+++ b/zh/deploy/astrbot/termux.md
@@ -83,35 +83,26 @@ proot-distro login ubuntu
 
 此时便进入了`Ubuntu环境`，我们需使用`apt`命令安装软件包了
 
-## 添加第三方PPA
+## 安装python环境
 
->[!TIP]
->`Python 3.10`并不在官方的软件源中，而`uv`所要求的Python版本为3.10 ，所以进行此步为必须
+全部复制以下语句中运行，即可自动安装python3.10
 
-### 使用`apt`安装`software-properties-common` (添加PPA前置)
-
-<!--这里不直接放termux基础环境里运行是因为他会报错，而且proot-distro也不大，性能损耗也很小-->
-
-<!--这里如果安装 miniconda 或者 anaconda 都会有报错，不知道为什么-->
-
+<!-- 这里优化了大陆网络环境，修复了miniconda报错问题 -->
 ```bash
-apt update && apt install software-properties-common
-```
-
-### 添加`deadsnakes`PPA(Python官方维护)
-
-```bash
-add-apt-repository ppa:deadsnakes/ppa && apt update
-```
-
-添加时你可能会看到:`Press [ENTER] to continue or Ctrl-c to cancel.` ，此时按下回车(换行)即可
-
-## 安装 `Python`
-
-在进行完以上步骤后，即可安装`Python 3.10`
-
-```bash
-apt install python3.10
+cat > install-py310.sh << EOF
+echo -e "\e[32m 开始安装python3.10 \e[0m - ASTRBOT"
+apt update
+apt install wget -y
+export SHELL=/bin/bash
+export miniconda_version="Miniconda3-py310_25.9.1-3-Linux-aarch64.sh"
+wget https://mirrors.tuna.tsinghua.edu.cn/anaconda/miniconda/${miniconda_version}
+chmod +x $miniconda_version
+./$miniconda_version -bcu
+source ~/.bashrc
+echo -e "\e[32m 成功安装： \e[0m"
+python --version
+EOF
+chmod +x install-py310.sh&&./install-py310.sh
 ```
 
 ## 克隆 `AstrBot` 仓库


### PR DESCRIPTION
# 本PR解决了大陆地区下载PDubuntu的tarball过慢的问题
# 修改：并将由原来的第三方PPA安装改为从miniconda安装python（自#86 ）

## Summary by Sourcery

改进 AstrBot 的 Termux 部署文档，以更好地支持 Python 3.10 的安装，并优化中国大陆地区的下载体验。

Documentation:
- 记录一个备用的 proot-distro tarball 镜像及其校验和，加快中国大陆地区下载 Ubuntu 镜像的速度。
- 使用基于 Miniconda 的安装脚本（采用清华镜像）替换之前基于 PPA 的 Python 3.10 安装步骤，并补充说明如有需要可切换到官方 Anaconda 仓库。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Termux deployment docs for AstrBot to better support Python 3.10 installation and downloads in mainland China.

Documentation:
- Document an alternative proot-distro tarball mirror and checksum to speed up Ubuntu image downloads in mainland China.
- Replace the previous PPA-based Python 3.10 installation steps with a Miniconda-based install script using Tsinghua mirrors, including a note on switching to the official Anaconda repo if needed.

</details>