### PR TITLE
从侧边栏移除旧开发文档

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -191,7 +191,6 @@ export default defineConfig({
                   { text: "会话控制器", link: "/guides/session-control" },
                   { text: "杂项", link: "/guides/other" },
                   { text: "发布插件", link: "/plugin-publish" },
-                  { text: "插件指南（旧）", link: "/plugin" },
                 ],
               },
               {

--- a/zh/dev/star/plugin.md
+++ b/zh/dev/star/plugin.md
@@ -1,5 +1,10 @@
 ---
 outline: deep
+search: false
+head:
+  - - meta
+    - name: robots
+      content: noindex
 ---
 
 # 插件开发指南（旧）


### PR DESCRIPTION
不认为被标记过时的开发文档仍然显示在侧边栏上。

此 PR 将旧开发文档从侧栏移除，同时防止搜索引擎和站内搜索索引此文档。\
用户仍然可以通过输入该文档的 URL 访问该文档。

## Summary by Sourcery

Documentation:
- 将旧的插件开发指南标记为不可被索引，并将其从文档侧边栏导航中隐藏。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Mark the old plugin development guide as non-indexable and hide it from the documentation sidebar navigation.

</details>