### PR TITLE
fix: 将 field 替换为 Field 以符合 Pydantic 模型定义规范

### DIFF
--- a/zh/dev/star/guides/ai.md
+++ b/zh/dev/star/guides/ai.md
@@ -152,7 +152,7 @@ class AssignAgentTool(FunctionTool[AstrAgentContext]):
 
     name: str = "assign_agent"
     description: str = "Assign an agent to a task based on the given query"
-    parameters: dict = field(
+    parameters: dict = Field(
         default_factory=lambda: {
             "type": "object",
             "properties": {
@@ -179,7 +179,7 @@ class WeatherTool(FunctionTool[AstrAgentContext]):
 
     name: str = "weather"
     description: str = "Get weather information for a location"
-    parameters: dict = field(
+    parameters: dict = Field(
         default_factory=lambda: {
             "type": "object",
             "properties": {
@@ -207,7 +207,7 @@ class SubAgent1(FunctionTool[AstrAgentContext]):
 
     name: str = "subagent1_name"
     description: str = "subagent1_description"
-    parameters: dict = field(
+    parameters: dict = Field(
         default_factory=lambda: {
             "type": "object",
             "properties": {
@@ -244,7 +244,7 @@ class SubAgent2(FunctionTool[AstrAgentContext]):
 
     name: str = "subagent2_name"
     description: str = "subagent2_description"
-    parameters: dict = field(
+    parameters: dict = Field(
         default_factory=lambda: {
             "type": "object",
             "properties": {


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 在 AI 工具指南中，将 Pydantic 模型示例中 `parameters` 属性使用的 `field` 更正为 `Field`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Correct the Pydantic model examples in the AI tools guide to use Field instead of field for the parameters attribute.

</details>