### PR TITLE
fix（docker-compose而不是docker）

### DIFF
--- a/en/deploy/platform/aiocqhttp/napcat.md
+++ b/en/deploy/platform/aiocqhttp/napcat.md
@@ -121,7 +121,7 @@ docker logs napcat
 - 勾选 `启用`。
 - `URL` 填写 `ws://宿主机IP:端口/ws`。如 `ws://localhost:6199/ws`或`ws://127.0.0.1:6199/ws`。
 
-> 注意如果是docker部署（用的本文档的docker脚本）那么填写的应该是`ws://astrbot:6199/ws`
+> 注意如果是docker部署（例如用的本文档的docker-compose脚本）那么填写的应该是`ws://astrbot:6199/ws`
 
 - 消息格式：`Array`
 - 心跳间隔: `5000`


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- 更新 Napcat 部署指南，将 WebSocket URL 配置部分从引用通用的 docker 脚本改为引用 docker-compose 脚本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update Napcat deployment guide to reference docker-compose scripts instead of generic docker scripts for WebSocket URL configuration.

</details>