### PR TITLE
docs: revise t2i docs

### DIFF
--- a/en/others/self-host-t2i.md
+++ b/en/others/self-host-t2i.md
@@ -1,23 +1,28 @@
-# 自行部署文转图服务
+# Self-host the Text-to-Image Service
 
-AstrBot 使用 [AstrBotDevs/astrbot-t2i-service](https://github.com/AstrBotDevs/astrbot-t2i-service) 项目作为默认的文本转图像服务。默认使用的文转图服务接口是
+AstrBot uses [AstrBotDevs/astrbot-t2i-service](https://github.com/AstrBotDevs/astrbot-t2i-service) as the default text-to-image service. The default service endpoints are:
 
 ```plain
 https://t2i.soulter.top/text2img
 https://t2i.rcfortress.site/text2img
 ```
 
-此接口能够保障大部分时间正常响应。但是由于部署在国外的（纽约）服务器，因此响应速度可能会比较慢。
+This interface can ensure normal response for most of the time. However, due to the deployment of servers in New York, the response speed may be slower in some areas.
 
 > [!TIP]
-> 欢迎通过 [爱发电](https://afdian.com/a/astrbot_team) 支持我们，以帮助我们支付服务器费用。
+> If you'd like to support us to help pay for server costs, please consider supporting us on [Afdian](https://afdian.com/a/astrbot_team).
 
-您可以选择自行部署文转图服务，以提升响应速度。
+You can choose to self-host the text-to-image service to improve response speed.
 
 ```bash
 docker run -itd -p 8999:8999 soulter/astrbot-t2i-service:latest
 ```
 
-在部署完成后，前往 AstrBot 面板 -> 配置 -> 其他配置，修改`文本转图像服务接口` 为你部署好的 url。
+After deployment, go to AstrBot Dashboard -> Config -> System, and change `Text-to-Image Service API Endpoint` to the URL you deployed (as shown below).
 
-> 如果部署在与 AstrBot 相同的机器上，url 应该为 `http://localhost:8999`。
+> If you deployed AstrBot using the Docker tutorial in this documentation, the URL should be `http://<t2i-service-container-name>:8999`.
+
+> If you deployed on the same machine as AstrBot, the URL should be `http://localhost:8999`.
+
+<img width="589" height="255" alt="image" src="https://github.com/user-attachments/assets/5ef09db2-1a33-440c-9986-c7b544325e34" />
+

--- a/zh/others/self-host-t2i.md
+++ b/zh/others/self-host-t2i.md
@@ -18,6 +18,10 @@ https://t2i.rcfortress.site/text2img
 docker run -itd -p 8999:8999 soulter/astrbot-t2i-service:latest
 ```
 
-在部署完成后，前往 AstrBot 面板 -> 配置 -> 其他配置，修改`文本转图像服务接口` 为你部署好的 url。
+在部署完成后，前往 AstrBot 仪表盘 -> 配置文件 -> 系统，修改 `文本转图像服务 API 地址` 为你部署好的 url（如下图所示）
 
-> 如果部署在与 AstrBot 相同的机器上，url 应该为 `http://localhost:8999`。
+>如果你是使用本文档的 Docker教程 部署的 AstrBot ，url应为  `http://文转图服务容器名:8999`。
+
+>如果部署在与 AstrBot 相同的机器上，url 应为 `http://localhost:8999`。
+
+<img width="591" height="228" alt="image" src="https://github.com/user-attachments/assets/f3564b46-11a4-402a-85e3-5f44a82713fe" />


### PR DESCRIPTION
原文已经过时，且部分信息不准确

## Summary by Sourcery

文档：
- 阐明如何在 AstrBot 控制台中配置文本转图片服务的 API 地址，包括针对 Docker 的配置示例和本地（localhost）URL 示例，并添加示意截图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Clarify how to configure the text-to-image service API address in the AstrBot dashboard, including Docker-specific and localhost URL examples, and add an illustrative screenshot.

</details>