### PR TITLE
fix(plugin-config):错误的配图

### DIFF
--- a/zh/dev/star/guides/plugin-config.md
+++ b/zh/dev/star/guides/plugin-config.md
@@ -64,7 +64,7 @@ AstrBot 提供了”强大“的配置解析和可视化功能。能够让用户
 
 **_special** 字段仅 v4.0.0 之后可用。目前支持填写 `select_provider`, `select_provider_tts`, `select_provider_stt`, `select_persona`，用于让用户快速选择用户在 WebUI 上已经配置好的模型提供商、人设等数据。结果均为字符串。以 select_provider 为例，将呈现以下效果:
 
-![image](/source/images/plugin/image.png)
+![image](/source/images/plugin/image-select-provider.png)
 
 ### dict 类型的 schema
 
@@ -153,6 +153,7 @@ AstrBot 提供了”强大“的配置解析和可视化功能。能够让用户
   }
 }
 ```
+
 保存后的 config 为
 
 ```json


### PR DESCRIPTION
将插件配置中special字段的配图换成provider选择的配图

## Summary by Sourcery

更新插件配置指南中的文档图片与格式。

文档：
- 将插件配置指南中 `special` 字段的示例图片替换为正确的提供商选择示意图。
- 调整空白间距，并确保插件配置 Markdown 文档以正确的文件结尾结束。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update plugin configuration guide documentation images and formatting.

Documentation:
- Replace the example image for the `special` field with the correct provider selection illustration in the plugin configuration guide.
- Tweak spacing and ensure proper file termination in the plugin configuration Markdown document.

</details>