### PR TITLE
更新了Linux工具箱脚本的部署链接

### DIFF
--- a/zh/deploy/astrbot/community-deployment.md
+++ b/zh/deploy/astrbot/community-deployment.md
@@ -19,7 +19,7 @@ bash -c "$(curl -L https://gitee.com/nasyt/nasyt-linux-tool/raw/master/nasyt.sh)
 使用 `curl` 去下载脚本并且使用 `bash` 执行脚本：
 
 ```bash
-bash <(curl -sSL https://raw.githubusercontent.com/zhende1113/Antlia/refs/heads/main/Script/AstrBot/Antlia.sh)
+bash -c "$(curl -L https://raw.gitcode.com/nasyt/nasyt-linux-tool/raw/master/nasyt_install.sh)"
 ```
 
 如果你的系统没有 `curl`，你可以使用 `wget`：


### PR DESCRIPTION
原作者的gitee仓库已无法访问，他自己也换成gitcode了

## Summary by Sourcery

文档：
- 更新 AstrBot 社区部署指南中的 Linux 工具箱部署命令，使其指向维护者新的 GitCode 仓库脚本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Refresh the Linux toolbox deployment command in the AstrBot community deployment guide to point to the maintainer's new GitCode repository script.

</details>