### PR TITLE
增加python版本过高案例以及解决办法

### DIFF
--- a/zh/deploy/astrbot/windows.md
+++ b/zh/deploy/astrbot/windows.md
@@ -84,7 +84,7 @@ windows 搜索 Python，打开文件位置：
 
 ## 报错2：You require CPython 3.14 (`cp314`)
 
-如果出现如下内容的报错，这是由于 Python 版本过高导致的，AstrBot 目前只**支持 Python 3.10–3.13**
+如果出现如下内容的报错，这是由于 Python 3.14 非常新，faiss-cpu 官方还没有编译出适配 3.14 的版本。因此，安装程序找不到对应的库，你可以安装 **Python 3.10–3.13**  来规避此问题。
 
 ```
   x No solution found when resolving dependencies:
@@ -93,10 +93,19 @@ windows 搜索 Python，打开文件位置：
 
       hint: You require CPython 3.14 (`cp314`), but we only found wheels for `faiss-cpu` (v1.10.0) with the following
       Python ABI tags: `cp39`, `cp310`, `cp311`, `cp312`, `cp313`
+...
 ```
 
 <img width="1756" height="874" alt="image" src="https://github.com/user-attachments/assets/a41df66e-d0f4-4033-b633-046daafc272f" />
 
-**解决办法：**
+**解决办法1：**
 
-卸载3.14+版本的 Python ，安装 *Python 3.10–3.13* 之间的任一版本，并且在安装时 **勾选 Add Python to PATH** ，然后重启电脑。
+卸载3.14+版本的 Python ，安装 *Python 3.10–3.13* 之间的任一版本，并且在安装时 **勾选 Add Python to PATH** ，删除生成的 AstrBot 文件夹，然后重启电脑，重新运行安装脚本。
+
+> 华为云镜像站：[Python3.12.5](https://mirrors.huaweicloud.com/python/3.12.5/python-3.12.5-amd64.exe) 或 [其他版本](https://mirrors.huaweicloud.com/python/)
+
+**解决办法2：**
+
+保留 Python 3.14 ，安装 *Python 3.10–3.13* 之间的任一版本，参照 **报错1：Python is not installed** 的 **方法1** 进行操作。
+
+> PS：既然官方没有给 Python 3.14 提供预编译好的二进制包（Wheel），你可以尝试本地编译，但是极大概率会遇到各种复杂的编译错误，非常耗时且容易折腾崩，这里并不推荐。

--- a/zh/deploy/astrbot/windows.md
+++ b/zh/deploy/astrbot/windows.md
@@ -56,7 +56,7 @@
 > 如果部署不了，请参阅其他两个部署方式：Docker 部署和 手动部署。
 
 
-## 报错：Python is not installed
+## 报错1：Python is not installed
 
 如果提示 Python is not installed，并且已经安装 Python，并且**也已经重启并仍报这个错误**，说明环境变量不对，有两个方法解决：
 
@@ -70,12 +70,33 @@ windows 搜索 Python，打开文件位置：
 
 ![alt text](/source/images/windows/image-1.png)
 
-复制文件地址：
+复制 `python.exe` 文件地址：
 
 ![image](/source/images/windows/image-2.png)
 
 回到 `launcher_astrbot_en.bat` 文件，右键点击 `在记事本中编辑`，找到 `set PYTHON_CMD=python` 这一行，将 `python` 改为你的 Python 解释器路径或指令，路径两端的双引号不要删。
 
+> Windows11 以下版本不能复制文件地址的，可以先复制文件夹地址再添加 /python.exe 和英文双引号
+
 **方法 2:**
 
 重装 python，并且在安装时勾选 `Add Python to PATH`，然后重启电脑。
+
+## 报错2：You require CPython 3.14 (`cp314`)
+
+如果出现如下内容的报错，这是由于 Python 版本过高导致的，AstrBot 目前只**支持 Python3.13.x ~ 3.10**
+
+```
+  x No solution found when resolving dependencies:
+  `-> Because faiss-cpu==1.10.0 has no wheels with a matching Python ABI tag (e.g., `cp314`) and you require
+      faiss-cpu==1.10.0, we can conclude that your requirements are unsatisfiable.
+
+      hint: You require CPython 3.14 (`cp314`), but we only found wheels for `faiss-cpu` (v1.10.0) with the following
+      Python ABI tags: `cp39`, `cp310`, `cp311`, `cp312`, `cp313`
+```
+
+<img width="1756" height="874" alt="image" src="https://github.com/user-attachments/assets/a41df66e-d0f4-4033-b633-046daafc272f" />
+
+**解决办法：**
+
+卸载3.14.x版本的 Python ，安装 *Python 3.13.x ~ 3.10* 之间的任意版本，并且在安装时**勾选 Add Python to PATH**，然后重启电脑。

--- a/zh/deploy/astrbot/windows.md
+++ b/zh/deploy/astrbot/windows.md
@@ -58,7 +58,7 @@
 
 ## 报错1：Python is not installed
 
-如果提示 Python is not installed，并且已经安装 Python，并且**也已经重启并仍报这个错误**，说明环境变量不对，有两个方法解决：
+如果提示 Python is not installed，并且已经安装 Python，并且**重启电脑仍报这个错误**，说明环境变量不对，有两个方法解决：
 
 **方法 1:**
 
@@ -84,7 +84,7 @@ windows 搜索 Python，打开文件位置：
 
 ## 报错2：You require CPython 3.14 (`cp314`)
 
-如果出现如下内容的报错，这是由于 Python 版本过高导致的，AstrBot 目前只**支持 Python3.13.x ~ 3.10**
+如果出现如下内容的报错，这是由于 Python 版本过高导致的，AstrBot 目前只**支持 Python 3.10–3.13**
 
 ```
   x No solution found when resolving dependencies:
@@ -99,4 +99,4 @@ windows 搜索 Python，打开文件位置：
 
 **解决办法：**
 
-卸载3.14.x版本的 Python ，安装 *Python 3.13.x ~ 3.10* 之间的任意版本，并且在安装时**勾选 Add Python to PATH**，然后重启电脑。
+卸载3.14+版本的 Python ，安装 *Python 3.10–3.13* 之间的任一版本，并且在安装时 **勾选 Add Python to PATH** ，然后重启电脑。

--- a/zh/deploy/astrbot/windows.md
+++ b/zh/deploy/astrbot/windows.md
@@ -56,7 +56,7 @@
 > 如果部署不了，请参阅其他两个部署方式：Docker 部署和 手动部署。
 
 
-## 报错1：Python is not installed
+## 常见报错 1：Python is not installed
 
 如果提示 Python is not installed，并且已经安装 Python，并且**重启电脑仍报这个错误**，说明环境变量不对，有两个方法解决：
 
@@ -82,7 +82,7 @@ windows 搜索 Python，打开文件位置：
 
 重装 python，并且在安装时勾选 `Add Python to PATH`，然后重启电脑。
 
-## 报错2：You require CPython 3.14 (`cp314`)
+## 常见报错 2：You require CPython 3.14 (`cp314`)
 
 如果出现如下内容的报错，这是由于 Python 3.14 非常新，faiss-cpu 官方还没有编译出适配 3.14 的版本。因此，安装程序找不到对应的库，你可以安装 **Python 3.10–3.13**  来规避此问题。
 


### PR DESCRIPTION
Updated error messages and solutions for Python installation issues.
增加python版本过高（3.14+）案例以及解决办法。

## Summary by Sourcery

更新 AstrBot 的 Windows 部署文档，明确 Python 错误处理方式，并新增对不受支持的高版本 Python 的使用说明。

Documentation:
- 明确在 Windows 上解决“未安装 Python（Python is not installed）”错误的步骤，包括如何定位并引用 `python.exe`。
- 记录在 AstrBot 中使用不受支持的 Python 3.14+ 版本时的新错误场景，并说明兼容的 Python 版本范围。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Windows deployment documentation for AstrBot with clarified Python error handling and new guidance for unsupported high Python versions.

Documentation:
- Clarify instructions for resolving 'Python is not installed' errors on Windows, including how to locate and reference python.exe.
- Document a new error scenario for using unsupported Python 3.14+ with AstrBot and explain the compatible version range.

</details>