### PR TITLE
需要配置环境变量的mcp服务器配置说明

### DIFF
--- a/en/use/mcp.md
+++ b/en/use/mcp.md
@@ -72,7 +72,7 @@ We extract the necessary information:
 }
 ```
 
-If the MCP server you need requires environment variables to configure something (e.g. access token), you could use commandline tool `env`:
+If the MCP server you need requires environment variables to configure something (e.g. access token), you could use the command-line tool `env`:
 
 ```json
 {

--- a/en/use/mcp.md
+++ b/en/use/mcp.md
@@ -72,6 +72,24 @@ We extract the necessary information:
 }
 ```
 
+If the MCP server you need requires environment variables to configure something (e.g. access token), you could use commandline tool `env`:
+
+```json
+{
+    "command": "env",
+    "args": [
+        "XXX_RESOURCE_FROM=local",
+        "XXX_API_URL=https://xxx.com",
+        "XXX_API_TOKEN=sk-xxxxx",
+        "uv",
+        "tool",
+        "run",
+        "xxx-mcp-server",
+        "--storage-path", "data/res"
+    ]
+}
+```
+
 Configure it in the AstrBot WebUI:
 
 ![image](https://files.astrbot.app/docs/en/use/image-2.png)

--- a/zh/use/mcp.md
+++ b/zh/use/mcp.md
@@ -71,6 +71,24 @@ npx -v
 }
 ```
 
+如果要使用的 MCP 服务器需要通过环境变量配置 Token 等信息，可以使用 `env` 这个工具：
+
+```json
+{
+    "command": "env",
+    "args": [
+        "XXX_RESOURCE_FROM=local",
+        "XXX_API_URL=https://xxx.com",
+        "XXX_API_TOKEN=sk-xxxxx",
+        "uv",
+        "tool",
+        "run",
+        "xxx-mcp-server",
+        "--storage-path", "data/res"
+    ]
+}
+```
+
 在 AstrBot WebUI 中设置:
 
 ![image](https://files.astrbot.app/docs/zh/use/image-2.png)


### PR DESCRIPTION
## Summary by Sourcery

在英文和中文使用指南中说明如何配置需要环境变量的 MCP 服务器。

文档：
- 在英文示例中展示如何在运行 MCP 服务器时使用 `env` 命令传递环境变量。
- 添加相应的中文示例，说明如何使用 `env` 工具为 MCP 服务器进行基于环境变量的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document how to configure MCP servers that require environment variables in both English and Chinese usage guides.

Documentation:
- Add an English example showing how to use the `env` command to pass environment variables when running an MCP server.
- Add a corresponding Chinese example explaining environment-variable-based configuration for MCP servers using the `env` tool.

</details>