### PR TITLE
docs: 增加 AstrBot-desktop 部署介绍

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -56,6 +56,7 @@ export default defineConfig({
                 link: "/astrbot/other-deployments",
                 collapsed: true,
                 items: [
+                  { text: "桌面客户端部署", link: "/astrbot/desktop" },
                   { text: "CasaOS 部署", link: "/astrbot/casaos" },
                   { text: "优云智算 GPU 部署", link: "/astrbot/compshare" },
                   { text: "社区提供的部署方式", link: "/astrbot/community-deployment" },

--- a/zh/deploy/astrbot/desktop.md
+++ b/zh/deploy/astrbot/desktop.md
@@ -1,0 +1,16 @@
+# 使用 AstrBot 桌面客户端部署
+
+`AstrBot-desktop` 适合在本地电脑快速部署和使用 AstrBot，支持 Windows、macOS、Linux。
+
+仓库地址：[AstrBotDevs/AstrBot-desktop](https://github.com/AstrBotDevs/AstrBot-desktop)
+
+## 下载并安装
+
+1. 打开 [AstrBot-desktop Releases](https://github.com/AstrBotDevs/AstrBot-desktop/releases)。
+2. 下载与你系统对应的安装包（如 `.exe`、`.dmg`、`.rpm`、`.deb`）。
+3. 安装完成后启动桌面客户端，按向导完成初始化。
+
+## 适用场景
+
+- 适合个人本地使用、快速体验。
+- 不建议用于服务器长期运行场景。

--- a/zh/deploy/astrbot/other-deployments.md
+++ b/zh/deploy/astrbot/other-deployments.md
@@ -1,5 +1,6 @@
 # 其他部署方式
 
+- [桌面客户端部署](./desktop.md)
 - [CasaOS 部署](./casaos.md)
 - [优云智算 GPU 部署](./compshare.md)
 - [社区提供的部署方式](./community-deployment.md)


### PR DESCRIPTION
## 背景
为部署文档补充 `AstrBot-desktop` 的入口和说明，方便用户在“部署方式”中直接找到桌面端部署方案。

## 变更内容
- 新增桌面客户端部署文档：`zh/deploy/astrbot/desktop.md`
- 在“其他部署方式”页面增加桌面客户端入口：`zh/deploy/astrbot/other-deployments.md`
- 在文档侧边栏“部署”导航中增加“桌面客户端部署”：`.vitepress/config.mjs`
- 修正文档中的 Linux 安装包描述为 `.rpm` / `.deb`

## 影响范围
- 中文部署文档导航与内容
- 不涉及代码逻辑与运行时行为变更

## 关联链接
- https://github.com/AstrBotDevs/AstrBot-desktop
