### PR TITLE
文档：勘误一处未及时更新的称呼

### DIFF
--- a/zh/faq.md
+++ b/zh/faq.md
@@ -89,7 +89,7 @@
 
 解决方法：
 
-结合报错信息，参考插件的 README 手动安装依赖库。你可以在 AstrBot WebUI 的 `控制台` -> `安装 Pip 库` 中安装依赖库。
+结合报错信息，参考插件的 README 手动安装依赖库。你可以在 AstrBot WebUI 的 `平台日志` -> `安装 Pip 库` 中安装依赖库。
 
 ![image](https://files.astrbot.app/docs/source/images/faq/image-1.png)
 


### PR DESCRIPTION
“控制台”应该是旧版本的叫法，现在webUI上显示的是“平台日志”

## Summary by Sourcery

文档：
- 在中文常见问题解答中，将过时的「控制台」标签替换为当前的「平台日志」标签，以与 WebUI 保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Replace the outdated '控制台' label with the current '平台日志' label in the Chinese FAQ to match the WebUI.

</details>