### PR TITLE
docs: 完善 _special 配置项说明并补充 select_knowledgebase 返回类型

### DIFF
--- a/en/dev/star/guides/plugin-config.md
+++ b/en/dev/star/guides/plugin-config.md
@@ -62,7 +62,7 @@ When the code editor is enabled, it looks like this:
 
 ![editor_mode_fullscreen](https://files.astrbot.app/docs/source/images/plugin/image-7.png)
 
-The **_special** field is only available after v4.0.0. Currently supports `select_provider`, `select_provider_tts`, `select_provider_stt`, `select_persona`, allowing users to quickly select model providers, personas, and other data already configured in the WebUI. Results are all strings. Using select_provider as an example, it will present the following effect:
+The **_special** field is only available after v4.0.0. Common values include `select_provider`, `select_provider_tts`, `select_provider_stt`, `select_persona`, and `select_knowledgebase`, allowing users to quickly select model providers, personas, knowledge bases, and other data already configured in the WebUI. `select_provider`, `select_provider_tts`, `select_provider_stt`, and `select_persona` return strings; `select_knowledgebase` returns a `list` and supports multiple selection, so the corresponding config item should use `type: list` with a default value of `[]`. In addition, AstrBot Core also uses `_special` values such as `select_providers`, `provider_pool`, `persona_pool`, `select_plugin_set`, `t2i_template`, `get_embedding_dim`, and `select_agent_runner_provider:*`. Using `select_provider` as an example, it will present the following effect:
 
 ![image](https://files.astrbot.app/docs/source/images/plugin/image-select-provider.png)
 

--- a/en/dev/star/guides/plugin-config.md
+++ b/en/dev/star/guides/plugin-config.md
@@ -62,7 +62,15 @@ When the code editor is enabled, it looks like this:
 
 ![editor_mode_fullscreen](https://files.astrbot.app/docs/source/images/plugin/image-7.png)
 
-The **_special** field is only available after v4.0.0. Common values include `select_provider`, `select_provider_tts`, `select_provider_stt`, `select_persona`, and `select_knowledgebase`, allowing users to quickly select model providers, personas, knowledge bases, and other data already configured in the WebUI. `select_provider`, `select_provider_tts`, `select_provider_stt`, and `select_persona` return strings; `select_knowledgebase` returns a `list` and supports multiple selection, so the corresponding config item should use `type: list` with a default value of `[]`. In addition, AstrBot Core also uses `_special` values such as `select_providers`, `provider_pool`, `persona_pool`, `select_plugin_set`, `t2i_template`, `get_embedding_dim`, and `select_agent_runner_provider:*`. Using `select_provider` as an example, it will present the following effect:
+The **_special** field is only available after v4.0.0. Common values include `select_provider`, `select_provider_tts`, `select_provider_stt`, `select_persona`, and `select_knowledgebase`, allowing users to quickly select model providers, personas, knowledge bases, and other data already configured in the WebUI.
+
+- `select_provider`, `select_provider_tts`, `select_provider_stt`, and `select_persona` return strings.
+- `select_knowledgebase` returns a `list` and supports multiple selection, so the corresponding config item should use `type: list` with a default value of `[]`.
+
+> [!NOTE]
+> For reference, AstrBot Core also uses other internal `_special` values, such as `select_providers`, `provider_pool`, `persona_pool`, `select_plugin_set`, `t2i_template`, `get_embedding_dim`, and `select_agent_runner_provider:*`.
+
+Using `select_provider` as an example, it will present the following effect:
 
 ![image](https://files.astrbot.app/docs/source/images/plugin/image-select-provider.png)
 

--- a/zh/dev/star/guides/plugin-config.md
+++ b/zh/dev/star/guides/plugin-config.md
@@ -62,7 +62,15 @@ AstrBot 提供了”强大“的配置解析和可视化功能。能够让用户
 
 ![editor_mode_fullscreen](https://files.astrbot.app/docs/source/images/plugin/image-7.png)
 
-**_special** 字段仅 v4.0.0 之后可用。常用可填写值包括 `select_provider`, `select_provider_tts`, `select_provider_stt`, `select_persona`, `select_knowledgebase`，用于让用户快速选择用户在 WebUI 上已经配置好的模型提供商、人设、知识库等数据。其中 `select_provider`、`select_provider_tts`、`select_provider_stt`、`select_persona` 的结果为字符串；`select_knowledgebase` 的结果为 `list` 类型，支持多选，建议将对应配置项的 `type` 设为 `list`，默认值设为 `[]`。此外，AstrBot Core 内部还使用了 `select_providers`、`provider_pool`、`persona_pool`、`select_plugin_set`、`t2i_template`、`get_embedding_dim`、`select_agent_runner_provider:*` 等 `_special` 值。以 `select_provider` 为例，将呈现以下效果:
+**_special** 字段仅 v4.0.0 之后可用。常用可填写值包括 `select_provider`, `select_provider_tts`, `select_provider_stt`, `select_persona`, `select_knowledgebase`，用于让用户快速选择在 WebUI 上已经配置好的模型提供商、人设、知识库等数据。
+
+- `select_provider`、`select_provider_tts`、`select_provider_stt`、`select_persona` 的结果为字符串。
+- `select_knowledgebase` 的结果为 `list` 类型，支持多选，建议将对应配置项的 `type` 设为 `list`，默认值设为 `[]`。
+
+> [!NOTE]
+> 此外，AstrBot Core 内部还使用了 `select_providers`、`provider_pool`、`persona_pool`、`select_plugin_set`、`t2i_template`、`get_embedding_dim`、`select_agent_runner_provider:*` 等 `_special` 值，供参考。
+
+以 `select_provider` 为例，将呈现以下效果:
 
 ![image](https://files.astrbot.app/docs/source/images/plugin/image-select-provider.png)
 

--- a/zh/dev/star/guides/plugin-config.md
+++ b/zh/dev/star/guides/plugin-config.md
@@ -62,7 +62,7 @@ AstrBot 提供了”强大“的配置解析和可视化功能。能够让用户
 
 ![editor_mode_fullscreen](https://files.astrbot.app/docs/source/images/plugin/image-7.png)
 
-**_special** 字段仅 v4.0.0 之后可用。目前支持填写 `select_provider`, `select_provider_tts`, `select_provider_stt`, `select_persona`，用于让用户快速选择用户在 WebUI 上已经配置好的模型提供商、人设等数据。结果均为字符串。以 select_provider 为例，将呈现以下效果:
+**_special** 字段仅 v4.0.0 之后可用。常用可填写值包括 `select_provider`, `select_provider_tts`, `select_provider_stt`, `select_persona`, `select_knowledgebase`，用于让用户快速选择用户在 WebUI 上已经配置好的模型提供商、人设、知识库等数据。其中 `select_provider`、`select_provider_tts`、`select_provider_stt`、`select_persona` 的结果为字符串；`select_knowledgebase` 的结果为 `list` 类型，支持多选，建议将对应配置项的 `type` 设为 `list`，默认值设为 `[]`。此外，AstrBot Core 内部还使用了 `select_providers`、`provider_pool`、`persona_pool`、`select_plugin_set`、`t2i_template`、`get_embedding_dim`、`select_agent_runner_provider:*` 等 `_special` 值。以 `select_provider` 为例，将呈现以下效果:
 
 ![image](https://files.astrbot.app/docs/source/images/plugin/image-select-provider.png)
 

--- a/zh/dev/star/plugin.md
+++ b/zh/dev/star/plugin.md
@@ -783,7 +783,7 @@ AstrBot 提供了”强大“的配置解析和可视化功能。能够让用户
 
 ![editor_mode_fullscreen](https://files.astrbot.app/docs/source/images/plugin/image-7.png)
 
-**_special** 字段仅 v4.0.0 之后可用。目前支持填写 `select_provider`, `select_provider_tts`, `select_provider_stt`, `select_persona`，用于让用户快速选择用户在 WebUI 上已经配置好的模型提供商、人设等数据。结果均为字符串。以 select_provider 为例，将呈现以下效果:
+**_special** 字段仅 v4.0.0 之后可用。常用可填写值包括 `select_provider`, `select_provider_tts`, `select_provider_stt`, `select_persona`, `select_knowledgebase`，用于让用户快速选择用户在 WebUI 上已经配置好的模型提供商、人设、知识库等数据。其中 `select_provider`、`select_provider_tts`、`select_provider_stt`、`select_persona` 的结果为字符串；`select_knowledgebase` 的结果为 `list` 类型，支持多选，建议将对应配置项的 `type` 设为 `list`，默认值设为 `[]`。此外，AstrBot Core 内部还使用了 `select_providers`、`provider_pool`、`persona_pool`、`select_plugin_set`、`t2i_template`、`get_embedding_dim`、`select_agent_runner_provider:*` 等 `_special` 值。以 `select_provider` 为例，将呈现以下效果:
 
 ![image](https://files.astrbot.app/docs/source/images/plugin/image.png)
 

--- a/zh/dev/star/plugin.md
+++ b/zh/dev/star/plugin.md
@@ -783,9 +783,17 @@ AstrBot 提供了”强大“的配置解析和可视化功能。能够让用户
 
 ![editor_mode_fullscreen](https://files.astrbot.app/docs/source/images/plugin/image-7.png)
 
-**_special** 字段仅 v4.0.0 之后可用。常用可填写值包括 `select_provider`, `select_provider_tts`, `select_provider_stt`, `select_persona`, `select_knowledgebase`，用于让用户快速选择用户在 WebUI 上已经配置好的模型提供商、人设、知识库等数据。其中 `select_provider`、`select_provider_tts`、`select_provider_stt`、`select_persona` 的结果为字符串；`select_knowledgebase` 的结果为 `list` 类型，支持多选，建议将对应配置项的 `type` 设为 `list`，默认值设为 `[]`。此外，AstrBot Core 内部还使用了 `select_providers`、`provider_pool`、`persona_pool`、`select_plugin_set`、`t2i_template`、`get_embedding_dim`、`select_agent_runner_provider:*` 等 `_special` 值。以 `select_provider` 为例，将呈现以下效果:
+**_special** 字段仅 v4.0.0 之后可用。常用可填写值包括 `select_provider`, `select_provider_tts`, `select_provider_stt`, `select_persona`, `select_knowledgebase`，用于让用户快速选择在 WebUI 上已经配置好的模型提供商、人设、知识库等数据。
 
-![image](https://files.astrbot.app/docs/source/images/plugin/image.png)
+- `select_provider`、`select_provider_tts`、`select_provider_stt`、`select_persona` 的结果为字符串。
+- `select_knowledgebase` 的结果为 `list` 类型，支持多选，建议将对应配置项的 `type` 设为 `list`，默认值设为 `[]`。
+
+> [!NOTE]
+> 此外，AstrBot Core 内部还使用了 `select_providers`、`provider_pool`、`persona_pool`、`select_plugin_set`、`t2i_template`、`get_embedding_dim`、`select_agent_runner_provider:*` 等 `_special` 值，供参考。
+
+以 `select_provider` 为例，将呈现以下效果:
+
+![image](https://files.astrbot.app/docs/source/images/plugin/image-select-provider.png)
 
 **使用配置**
 


### PR DESCRIPTION
- 补充 select_knowledgebase 返回 list、支持多选
- 补充 _special 的常用取值及 Core 内部其他取值说明

## Summary by Sourcery

在插件配置指南中补充文档，说明额外的 `_special` 配置选项，并澄清 `select_knowledgebase` 的返回类型。

文档更新：
- 说明 `select_knowledgebase` 返回列表、支持多选，并且在插件配置文档中应与 `type: list` 和空列表默认值一起使用。
- 在英文和中文的插件文档中列出常见和内部使用的 `_special` 值，包括知识库相关，以及各种与 provider 和 pool 相关的选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document additional `_special` configuration options and clarify return types for `select_knowledgebase` in plugin configuration guides.

Documentation:
- Explain that `select_knowledgebase` returns a list, supports multi-select, and should be paired with `type: list` and an empty list default in plugin config docs.
- List common and internally used `_special` values, including knowledge base and various provider- and pool-related options, in both English and Chinese plugin documentation.

</details>